### PR TITLE
feat: read resolution from exposed variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           record: true
           group: '1. Resolution is high'
-          env: resolution=high
+          expose: resolution=high
           config: viewportWidth=1920,viewportHeight=1080
           browser: chrome
         env:
@@ -40,7 +40,7 @@ jobs:
           install: false
           record: true
           group: '2. Resolution is 4k'
-          env: resolution=4k
+          expose: resolution=4k
           # increase the viewport to capture more details
           config: viewportWidth=3840,viewportHeight=2160
           browser: chrome
@@ -55,7 +55,7 @@ jobs:
           install: false
           record: true
           group: '3. Resolution is 700x600'
-          env: resolution=700x600
+          expose: resolution=700x600
           config: viewportWidth=700,viewportHeight=600
           browser: chrome
         env:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ Or a high resolution
 }
 ```
 
+Use on CI for example via [Cypress GitHub Action](https://github.com/cypress-io/github-action)
+
+```yml
+- name: Run tests in high resolution 🧪
+  # https://github.com/cypress-io/github-action
+  uses: cypress-io/github-action@v7
+  with:
+    record: true
+    group: '1. Resolution is high'
+    expose: resolution=high
+    config: viewportWidth=1920,viewportHeight=1080
+    browser: chrome
+  env:
+    DEBUG: cypress-high-resolution
+    CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+```
+
 **Tip:** when increasing the browser window size, it might make sense to increase the viewport used by the Cypress to use those pixels!
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm i -D cypress-high-resolution
 $ yarn add -D cypress-high-resolution
 ```
 
-### Cypress v10+
+### Cypress v15+
 
 Add this plugin to your Cypress config file
 
@@ -33,31 +33,21 @@ module.exports = defineConfig({
 })
 ```
 
-### Cypress v9
-
-Add this plugin to your Cypress plugin file
-
-```js
-// cypress/plugins/index.js
-module.exports = (on, config) => {
-  // https://github.com/bahmutov/cypress-high-resolution
-  require('cypress-high-resolution')(on, config)
-}
-```
+**Note:** older Cypress versions no longer supported, please use an older plugin version.
 
 ## Use
 
-When using non-interactive mode `cypress run`, you can specify the browser window size using the [Cypress environment variables](https://on.cypress.io/environment-variables) which can be passed via system OS environment variables, via `cypress.json` config file, via `cypress.env.json` file, or via command line arguments. For example, here is how to specify the video resolution using the command line arguments:
+When using non-interactive mode `cypress run`, you can specify the browser window size using the [Cypress public environment variables](https://on.cypress.io/environment-variables) which can be passed via system OS environment variables, via `cypress.json` config file, via `cypress.env.json` file, or via command line arguments. For example, here is how to specify the video resolution using the command line arguments:
 
-```
+```bash
 # generate ultra-high resolution 3840x2160 videos
-$ npx cypress run --env resolution=4k
+$ npx cypress run --expose resolution=4k
 # generate videos 1200x1000
-$ npx cypress run --env resolution=1200x1000
+$ npx cypress run --expose resolution=1200x1000
 # alternative way: use an array
-$ npx cypress run --env resolution=[1200,1000]
+$ npx cypress run --expose resolution=[1200,1000]
 # generate high resolution video 1920x1080
-$ npx cypress run --env resolution=high
+$ npx cypress run --expose resolution=high
 ```
 
 Specifying the output resolution using the system OS variables
@@ -69,11 +59,11 @@ CYPRESS_resolution=high npx cypress run
 CYPRESS_resolution=600x300 npx cypress run
 ```
 
-You can set the video resolution in the `cypress.json` file
+You can set the video resolution in the Cypress config file
 
 ```json
 {
-  "env": {
+  "expose": {
     "resolution": [1280, 720]
   }
 }
@@ -83,7 +73,7 @@ Or a high resolution
 
 ```json
 {
-  "env": {
+  "expose": {
     "resolution": "high"
   }
 }

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
   fixturesFolder: false,
   viewportWidth: 1440,
   viewportHeight: 1200,

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,6 @@ const label = 'cypress-high-resolution'
  * @see https://www.cypress.io/blog/2021/03/01/generate-high-resolution-videos-and-screenshots/
  */
 function registerVideoResolution(on, config) {
-  debug('Cypress config.env %o', config.env)
-
   on('task', {
     async getImageSize(imagePath) {
       const { imageSizeFromFile } = require('image-size/fromFile')
@@ -19,31 +17,36 @@ function registerVideoResolution(on, config) {
     },
   })
 
-  if (!config.env.resolution) {
+  const userResolution =
+    config.expose.resolution || process.env.CYPRESS_resolution
+
+  if (!userResolution) {
     debug('there is no resolution change')
     return
   }
+
+  debug('user requested resolution %o', userResolution)
 
   // defaults
   let browserWindowWidth = 1280
   let browserWindowHeight = 720
 
-  if (Array.isArray(config.env.resolution)) {
-    if (config.env.resolution.length !== 2) {
+  if (Array.isArray(userResolution)) {
+    if (userResolution.length !== 2) {
       throw new Error('resolution must be an array of length 2')
     }
-    browserWindowWidth = config.env.resolution[0]
-    browserWindowHeight = config.env.resolution[1]
+    browserWindowWidth = userResolution[0]
+    browserWindowHeight = userResolution[1]
   } else {
-    if (typeof config.env.resolution !== 'string') {
+    if (typeof userResolution !== 'string') {
       console.error(
         'resolution parameter should be a string, was passed %o',
-        config.env.resolution,
+        userResolution,
       )
       return
     }
 
-    const wantedResolution = config.env.resolution.toLowerCase()
+    const wantedResolution = userResolution.toLowerCase()
     if (wantedResolution === '4k') {
       browserWindowWidth = 3840
       browserWindowHeight = 2160
@@ -52,7 +55,7 @@ function registerVideoResolution(on, config) {
       browserWindowHeight = 1080
     } else if (/^\d+x\d+$/.test(wantedResolution)) {
       // passing the custom resolution using "width x height"
-      const [width, height] = config.env.resolution.split('x')
+      const [width, height] = userResolution.split('x')
       browserWindowWidth = parseInt(width, 10)
       browserWindowHeight = parseInt(height, 10)
     }
@@ -68,16 +71,23 @@ function registerVideoResolution(on, config) {
     debug('before:browser:launch browser info %o', browser)
 
     if (browser.name === 'electron' && browser.isHeadless) {
+      debug(
+        'setting electron window size to %d x %d',
+        browserWindowWidth,
+        browserWindowHeight,
+      )
       launchOptions.preferences.width = browserWindowWidth
       launchOptions.preferences.height = browserWindowHeight
     } else if (browser.name === 'chrome' && browser.isHeadless) {
-      launchOptions.args.push(
-        `--window-size=${browserWindowWidth},${browserWindowHeight}`,
-      )
-      launchOptions.args.push('--force-device-scale-factor=1')
+      const wsArg = `--window-size=${browserWindowWidth},${browserWindowHeight}`
+      const dpArg = `--force-device-scale-factor=1`
+      debug('adding chrome args %o', [wsArg, dpArg])
+      launchOptions.args.push(wsArg, dpArg)
     } else if (browser.name === 'firefox' && browser.isHeadless) {
-      launchOptions.args.push(`--width=${browserWindowWidth}`)
-      launchOptions.args.push(`--height=${browserWindowHeight}`)
+      const wArg = `--width=${browserWindowWidth}`
+      const hArg = `--height=${browserWindowHeight}`
+      debug('adding firefox args %o', [wArg, hArg])
+      launchOptions.args.push(wArg, hArg)
     }
 
     return launchOptions


### PR DESCRIPTION
BREAKING CHANGE: requires Cypress with `expose` support, read https://glebbahmutov.com/blog/cypress-expose/

closes #52 